### PR TITLE
Update hashmap.c

### DIFF
--- a/src/core/hashmap.c
+++ b/src/core/hashmap.c
@@ -115,6 +115,8 @@ swHashMap* swHashMap_new(uint32_t bucket_num, swHashMap_dtor dtor)
     if (!(root->hh.tbl))
     {
         swWarn("malloc for table failed.");
+        swHashMap_node_free(hmap, root);
+        sw_free(hmap);
         return NULL;
     }
 


### PR DESCRIPTION
This version first frees root (which is pointed to by hmap), and then hmap itself. Freeing hmap on its own is not enough (because it points to root which will leak). An alternative is:

```
sw_free(root);
sw_free(hmap);
```

But that's a little scarier.

Finally, there's also `swHashMap_free(hmap)`, which will go into `hmap` and free everything. But because infer doesn't detect this, we can rule it out.